### PR TITLE
Remove @ from default Twitter gallery template

### DIFF
--- a/app/logical/sites/definitions/twitter.yml
+++ b/app/logical/sites/definitions/twitter.yml
@@ -3,8 +3,8 @@ enum_value: twitter
 display_name: Twitter
 homepage: https://twitter.com
 gallery_templates:
-  - twitter.com/@{site_artist_identifier}
   - twitter.com/{site_artist_identifier}
+  - twitter.com/@{site_artist_identifier}
   - mobile.twitter.com/{site_artist_identifier}
 username_identifier_regex: "[a-zA-Z0-9_]{1,15}"
 submission_template: https://twitter.com/{site_artist_identifier}/status/{site_submission_identifier}


### PR DESCRIPTION
For some reason the Twitter for Android app doesn't like opening Twitter links that contain the @, resulting in a "_The term you entered did not bring up any results. Please try again later._" message. I've had this problem for a while now and I only just figured it out, assuming the _trying again later_ part would actually be helpful.

* https://twitter.com/@twitter
* https://twitter.com/twitter

When it actually works, the link including the @ just redirects to the @-less version anyways.