### PR TITLE
Additional URL format for Tumblr

### DIFF
--- a/app/logical/sites/definitions/tumblr.yml
+++ b/app/logical/sites/definitions/tumblr.yml
@@ -3,6 +3,7 @@ enum_value: tumblr
 display_name: Tumblr
 homepage: https://www.tumblr.com
 gallery_templates:
+  - tumblr.com/{site_artist_identifier}
   - "{site_artist_identifier}.tumblr.com"
 username_identifier_regex: "[a-zA-Z0-9-]{1,32}"
 submission_template: https://{site_artist_identifier}.tumblr.com/post/{site_submission_identifier}


### PR DESCRIPTION
Resolves #91 

Tested to work fine with the following URLs
* `https://www.tumblr.com/username`
* `https://tumblr.com/username`
* `https://username.tumblr.com`
* `https://www.username.tumblr.com` (I don't think that exists in the wild, but good to know it works)