### PR TITLE
Lower cache time for Art Fight cookie

### DIFF
--- a/app/logical/scraper/artfight.rb
+++ b/app/logical/scraper/artfight.rb
@@ -77,6 +77,6 @@ module Scraper
         driver.cookie_value("laravel_session")
       end
     end
-    cache(:fetch_cookie, 24.hours)
+    cache(:fetch_cookie, 55.minutes)
   end
 end


### PR DESCRIPTION
The session is much shorter than the cookie expiry time suggests. I didn't realise until the switch to httpx, which actually throws an error on a 302 status. 