### PR TITLE
Fix DeviantArt authentication

### DIFF
--- a/app/logical/scraper/deviantart.rb
+++ b/app/logical/scraper/deviantart.rb
@@ -88,7 +88,8 @@ module Scraper
         driver.wait_for_element(xpath: "//*[text()='Log In']").click
 
         driver.wait_for_element(id: "username").send_keys Config.deviantart_user
-        driver.find_element(id: "password").send_keys Config.deviantart_pass
+        driver.find_element(id: "loginbutton").click
+        driver.wait_for_element(id: "password").send_keys Config.deviantart_pass
         driver.find_element(id: "loginbutton").click
 
         begin


### PR DESCRIPTION
It's now a two-step process where you have to enter the username, navigate to a second page and then enter the password.

Without this change, Selenium fails with the following error because the password field no longer exists on the login page: `Selenium::WebDriver::Error::NoSuchElementError: no such element: Unable to locate element: {"method":"css selector","selector":"#password"}`