### PR TITLE
Allow searching by not in backlog

### DIFF
--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -257,7 +257,7 @@ class SubmissionFile < ApplicationRecord
       end
 
       def search_params
-        [:artist_id, :site_type, :upload_status, :corrupt, :zero_sources, :zero_artists, :larger_only_filesize_treshold, :content_type, :title, :description, { artist_url_id: [] }]
+        [:artist_id, :site_type, :upload_status, :corrupt, :zero_sources, :zero_artists, :larger_only_filesize_treshold, :content_type, :title, :description, { artist_url_id: [] }, :in_backlog]
       end
 
       def pagy(params)

--- a/app/views/submission_files/_search.html.erb
+++ b/app/views/submission_files/_search.html.erb
@@ -15,6 +15,10 @@
     ["Pictures Only", "image/png,image/jpeg,"],
   ], include_blank: true %>
   <%= f.input :site_type, label: "Site", collection: site_types_collection, include_blank: true %>
+  <%= f.input :in_backlog, label: "In Backlog?", collection: [
+    ["Yes", "true"],
+    ["No", "false"],
+  ], include_blank: true %>
   <%= f.input :title %>
   <%= f.input :description %>
   <%= f.input :corrupt, as: :boolean, label: "Corrupt?" %>

--- a/app/views/submission_files/_search.html.erb
+++ b/app/views/submission_files/_search.html.erb
@@ -16,8 +16,8 @@
   ], include_blank: true %>
   <%= f.input :site_type, label: "Site", collection: site_types_collection, include_blank: true %>
   <%= f.input :in_backlog, label: "In Backlog?", collection: [
-    ["Yes", "true"],
-    ["No", "false"],
+    %w[Yes true],
+    %w[No false],
   ], include_blank: true %>
   <%= f.input :title %>
   <%= f.input :description %>


### PR DESCRIPTION
Adds the ability to search submission files by files not in the backlog. This is useful because backlogged files are often used for files you plan to upload, so there's no reason to show them in the search anymore.

I'm not sure about others, but I usually use the submission file view to select posts to add to the backlog, so having ones already in my backlog there doesn't make a whole lot of sense

![xvr5so_18789 1](https://github.com/Earlopain/reverser/assets/61888458/00be5f96-f49c-485c-8514-de3bf5fb96d9)

I realize that searching by posts in backlog here also doesn't make sense because there's an entire tab for that, but I didn't think it would make sense to leave it out.