### PR TITLE
Update date format for Fur Affinity scraper (2)

### DIFF
--- a/app/logical/scraper/furaffinity.rb
+++ b/app/logical/scraper/furaffinity.rb
@@ -95,10 +95,10 @@ module Scraper
       element = html.css(".submission-id-container .popup_date").first
       begin
         # Full date format
-        DateTime.strptime(element.content.strip, "%B %d, %Y, %H:%M:%S")
+        DateTime.strptime(element.content.strip, "%B %d, %Y %I:%M:%S %p")
       rescue ArgumentError
         # Fuzzy date format
-        DateTime.strptime(element.attribute("title").content.strip, "%B %d, %Y, %H:%M:%S")
+        DateTime.strptime(element.attribute("title").content.strip, "%B %d, %Y %I:%M:%S %p")
       end
     end
 


### PR DESCRIPTION
As mentioned at #135, Fur Affinity changed their date format _again_.

Previous: `September 16, 2025, 20:49:05`
Current: `September 20, 2025 02:04:29 PM`

Hopefully they don't do it a third time any time soon.