### PR TITLE
Fix Art Fight scraper

### DIFF
--- a/app/logical/scraper/artfight.rb
+++ b/app/logical/scraper/artfight.rb
@@ -34,7 +34,7 @@ module Scraper
 
     def fetch_api_identifier
       html = fetch_html("https://artfight.net/~#{url_identifier}", headers: headers)
-      html.at(".btn.btn-danger.report-button")&.attribute("data-id")&.value
+      html.at(".block-button")&.attribute("data-id")&.value
     end
 
     private
@@ -68,8 +68,9 @@ module Scraper
         driver.wait_for_element(css: "input[name='username']").send_keys Config.artfight_user
         driver.find_element(css: "input[name='password']").send_keys Config.artfight_pass
         driver.find_element(css: "input[name='remember']").click
-        driver.find_element(css: "input[value='Sign in']").click
+        driver.find_element(css: "button[type='submit']").click
 
+        driver.wait_for_element(css: ".username-navbar")
         driver.cookie_value("laravel_session")
       end
     end


### PR DESCRIPTION
Fixes the Art Fight scraper so it runs again.

Firstly, there have seemingly been some changes to the website layout that needed altered CSS selectors to work correctly. 

Secondly, cookie behaviour has since changed: the `laravel_session` cookie now exists upon first visiting the website, with the value changing after a successful login, so the `fetch_cookie` method was returning early with the pre-authenticated cookie.

By awaiting the `.username-navbar` element, which only appears to authenticated users, we can assure a successful login before returning the cookie value. I wasn't convinced this was the best solution as it could be awaiting that element indefinitely if incorrect login details were supplied, but it does seem like it wouldn't be the only scraper with that issue.